### PR TITLE
Skip doctests for now because of RST errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,11 +59,8 @@ the following:
 Worked Examples
 ===============
 
-.. include:: ./tree/master/src/collective/listingviews/tests/listingviews.rst
-
-See the `doctests for a worked example`_
-
-.. _doctests for a worked example: ./src/collective/listingviews/tests/listingviews.rst
+See the doctests for a worked example:
+``./src/collective/listingviews/tests/listingviews.rst`` 
 
 Contributing
 ============


### PR DESCRIPTION
The RST conversion was failing because the ./tree/master/src/... path
wasn't resolving. Changing that to ./src/collective/... works, but
then listingviews.rst causes a bunch of RST errors. The doctests would
have to be edited.

Similarly, hyperlinking to a relative path won't work (certainly not from PyPI). Do we want to
link to the file in github instead?
