### PR TITLE
Errors in expressions

### DIFF
--- a/conf/test-4.2.x.cfg
+++ b/conf/test-4.2.x.cfg
@@ -52,4 +52,5 @@ eggs = ${plone:eggs}
 [versions]
 distribute = 0.6.27
 zc.buildout = 1.5.2
-
+plone.app.jquery = 1.7.2
+collective.js.jqueryui = 1.9.2.0

--- a/src/collective/listingviews/browser/portlets/portlets.py
+++ b/src/collective/listingviews/browser/portlets/portlets.py
@@ -174,6 +174,8 @@ class ListingRenderer(base.Renderer):
                 path = path[1:]
 
             return portal.restrictedTraverse(path, default=False)
+        except ConflictError:
+            raise
         except:
             return False
 

--- a/src/collective/listingviews/browser/views/base.py
+++ b/src/collective/listingviews/browser/views/base.py
@@ -235,7 +235,14 @@ class BaseListingInformationRetriever(BrowserView):
         def value(item):
             expression_context = getExprContext(self.context, self.context)
             expression_context.setLocal('item', item)
-            val = expression(expression_context)
+            try:
+                val = expression(expression_context)
+            except KeyError:
+                portal_membership = getToolByName(self, 'portal_membership')
+                if not portal_membership.checkPermission('Manage portal', self.context):
+                    return None
+                css_class = 'field error'
+                val = 'The custom field expression has an error: %s.' % expression.text
             return {'title': field.name, 'css_class': css_class, 'value': val, 'is_custom': True}
         return value
 

--- a/src/collective/listingviews/browser/views/base.py
+++ b/src/collective/listingviews/browser/views/base.py
@@ -6,7 +6,7 @@ from collective.listingviews.interfaces import IListingAdapter\
 try:
     from eea.facetednavigation.layout.interfaces import IFacetedLayout
     from eea.facetednavigation.subtypes.interfaces import IFacetedNavigable, IFacetedSearchMode
-except:
+except ImportError:
     IFacetedLayout = None
     IFacetedNavigable = None
     IFacetedSearchMode = None

--- a/src/collective/listingviews/browser/views/base.py
+++ b/src/collective/listingviews/browser/views/base.py
@@ -237,7 +237,7 @@ class BaseListingInformationRetriever(BrowserView):
             expression_context.setLocal('item', item)
             try:
                 val = expression(expression_context)
-            except KeyError:
+            except (AttributeError, IndexError, KeyError, NameError, TypeError, ValueError, ZeroDivisionError):
                 portal_membership = getToolByName(self, 'portal_membership')
                 if not portal_membership.checkPermission('Manage portal', self.context):
                     return None

--- a/src/collective/listingviews/browser/views/base.py
+++ b/src/collective/listingviews/browser/views/base.py
@@ -241,10 +241,8 @@ class BaseListingInformationRetriever(BrowserView):
                 portal_membership = getToolByName(self, 'portal_membership')
                 if not portal_membership.checkPermission('Manage portal', self.context):
                     return None
-                css_class = 'field error'
                 val = 'The custom field expression has an error: %s.' % expression.text
             return {'title': field.name, 'css_class': css_class, 'value': val, 'is_custom': True}
         return value
 
 # Override context creation
-

--- a/src/collective/listingviews/browser/views/templates/layout.pt
+++ b/src/collective/listingviews/browser/views/templates/layout.pt
@@ -20,11 +20,14 @@
             tal:attributes="class string:${class_name} listing-collection-view">
 
               <div class="listing-item-fields">
-                <dl class="item-fields" tal:attributes="class string:${class_name}-item item-fields" metal:define-macro="item_fields"><tal:fields
+                <dl class="item-fields" tal:attributes="class string:${class_name}-item item-fields" metal:define-macro="item_fields">
+                    <tal:fields
                         tal:repeat="field fields">
-                      <dt tal:content="string:${field/title}" tal:attributes="class string:listing-field ${field/css_class}"></dt>
-                      <dd tal:content="structure field/value" tal:attributes="class string:listing-field ${field/css_class}"></dd></tal:fields
-                     >
+                      <tal:condition condition="field">
+                          <dt tal:content="string:${field/title}" tal:attributes="class string:listing-field ${field/css_class}"></dt>
+                          <dd tal:content="structure field/value" tal:attributes="class string:listing-field ${field/css_class}"></dd>
+                      </tal:condition>
+                    </tal:fields>
                 </dl>
               </div>
               <tal:core-macro metal:define-macro="content-core"
@@ -34,11 +37,14 @@
 
               <ul class="listing-items-view" tal:attributes="class string:${class_name}-listing listing-items-view" metal:define-macro="listing_items">
                   <li class="listing-item" tal:repeat="item_object batch">
-                      <dl class="listing-fields"><tal:fields
-                          tal:repeat="field python:adapter.assemble_listing_information(item_object, True)">
+                      <dl class="listing-fields">
+                        <tal:fields repeat="field python:adapter.assemble_listing_information(item_object, True)">
+                          <tal:condition condition="field">
                               <dt tal:content="string:${field/title}" tal:attributes="class string:listing-field ${field/css_class}"></dt>
                               <dd tal:content="structure field/value" tal:attributes="class string:listing-field ${field/css_class}"></dd>
-                      </tal:fields></dl>
+                          </tal:condition>
+                        </tal:fields>
+                      </dl>
                   </li>
               </ul>
 

--- a/src/collective/listingviews/interfaces.py
+++ b/src/collective/listingviews/interfaces.py
@@ -6,7 +6,7 @@ from collective.listingviews import LVMessageFactory as _
 from validation import validate_id, validate_class, validate_tal
 try:
     from plone.autoform import directives as form
-except:
+except ImportError:
     from plone.directives import form
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.schema.interfaces import IContextSourceBinder, IVocabularyFactory

--- a/src/collective/listingviews/testing.py
+++ b/src/collective/listingviews/testing.py
@@ -34,14 +34,13 @@ class CollectiveListingviews(PloneSandboxLayer):
         portal.folder1.invokeFactory('Document', 'item1', title=u"item1")
         workflowTool = getToolByName(portal, 'portal_workflow')
         workflowTool.doActionFor(portal.folder1.item1, 'publish')
+        portal.folder1.reindexObject()
         portal.folder1.item1.setEffectiveDate('1/1/2001')
         portal.folder1.item1.reindexObject()
-
-        portal.folder1.invokeFactory('Topic', 'collection1', title=u"collection1")
+        portal.folder1.invokeFactory('Collection', 'collection1', title=u"collection1")
         topic = portal.folder1.collection1
-
-        path_crit = topic.addCriterion('path', 'ATRelativePathCriterion')
-        path_crit.setRelativePath('..')   # should give the parent==folderA1
+        topic.setQuery([{'i': 'path', 'o': 'plone.app.querystring.operation.string.relativePath', 'v': '..'}])
+        topic.reindexObject()
 
 class BrowserIntegrationTesting(IntegrationTesting):
 

--- a/src/collective/listingviews/vocabularies.py
+++ b/src/collective/listingviews/vocabularies.py
@@ -14,12 +14,7 @@ class LVVocabulary(SimpleVocabulary):
     """
 
     def __init__(self, terms, *interfaces, **config):
-        try:
-            super(LVVocabulary, self).__init__(terms, *interfaces)
-        except:
-            import pdb
-            pdb.set_trace()
-            raise
+        super(LVVocabulary, self).__init__(terms, *interfaces)
         if 'default' in config:
             self.default = config['default']
         else:
@@ -31,6 +26,8 @@ class LVVocabulary(SimpleVocabulary):
             return self.by_value[value]
         except KeyError:
             return self.by_value[self.default]
+        except ConflictError:
+            raise
         except:
             raise LookupError(value)
 


### PR DESCRIPTION
Hi,

This should fix issue #6. It silently fails if the user doesn't have permission to fix it, so only a user with Manage portal will see an error message, the non working field is just skipped otherwise. The error is quite hard to spot, adding some highlighting would be useful, but the error css classes in Plone don't work on the tags being used, and I didn't want to add in some product level css. There is also a scope issue created if you try to change the css_class on error.

Cheers
Michael
