### PR TITLE
WIP Provide item_object variable in tal expression.

### DIFF
--- a/src/collective/listingviews/browser/views/base.py
+++ b/src/collective/listingviews/browser/views/base.py
@@ -230,6 +230,7 @@ class BaseListingInformationRetriever(BrowserView):
         def value(item):
             expression_context = getExprContext(self.context, self.context)
             expression_context.setLocal('item', item)
+            expression_context.setLocal('item_object', item.getObject)
             val = expression(expression_context)
             return {'title': field.name, 'css_class': css_class, 'value': val, 'is_custom': True}
         return value


### PR DESCRIPTION
Issues with using the tal statement on a custom listing view in Plone 5. The tal statement provides a brain as `item` but calling `item.getObject()` is not allowed ttw.

This PR provides a variable `item_object` which is a reference to `item.getObject`.

To avoid unnecessary `getObject()` calls, only a reference to the function is provided, it must be called in the tal statement.

To do:

 - Add documentation for the additional variable
 - Optional: Provide other catalog callables (such as getURL)
 - Add tests
 - Update changelog